### PR TITLE
Support time zone name - %Z

### DIFF
--- a/lib/strftime.js
+++ b/lib/strftime.js
@@ -184,8 +184,10 @@ if (typeof Date.prototype.strftime == 'undefined') {
     }
 
     // time_zone_name
+    // works for most browsers but not all. some browsers like opera for example don't always provide the time zone name/abbreviation
     function time_zone_name(date) {
-      var tz_name = date.toTimeString().match(/\(?([A-Z]+)\)?$/)[1];
+      var tz_parts = date.toTimeString().match(/\(?([A-Z]*)[a-z ]*?([A-Z]*)[a-z ]*?([A-Z]*)[a-z ]*?([A-Z]*)[a-z ]*?\)?$/);
+      var tz_name = tz_parts.slice(1).join("")
       return tz_name;
     }
     

--- a/lib/strftime.js
+++ b/lib/strftime.js
@@ -77,7 +77,7 @@ if (typeof Date.prototype.strftime == 'undefined') {
           'X': default_local_time,
           'y': year_abbr,
           'Y': year,
-          // 'Z': time_zone_name,
+          'Z': time_zone_name,
           'z': time_zone_offset,
           '%': function() { return '%'; }
         };
@@ -181,6 +181,12 @@ if (typeof Date.prototype.strftime == 'undefined') {
     function time_zone_offset(date) {
       var tz_offset = date.getTimezoneOffset();
       return (tz_offset >= 0 ? '-' : '') + ('0' + (tz_offset / 60)).slice(-2) + ':' + ('0' + (tz_offset % 60)).slice(-2);
+    }
+
+    // time_zone_name
+    function time_zone_name(date) {
+      var tz_name = date.toTimeString().match(/\(?([A-Z]+)\)?$/)[1];
+      return tz_name;
     }
     
     // week_number_from_sunday

--- a/spec/lib/strftime_spec.js
+++ b/spec/lib/strftime_spec.js
@@ -163,22 +163,17 @@ Screw.Unit(function() {
     });
     
     describe("`%Z`", function(){
+      //| Might suffice to test formatting since browsers will 
+      //| automatically convert dates to the local timezone
       it ("should return the time zone name", function() {
-        expect(date.strftime("%Z")).to(equal, 'PDT');
+        expect((date.strftime("%Z").match(/-?[A-Z]{3,4}/)) != null).to(equal , true);
       });
     });
     
     describe("`%z`", function(){
-      // it ("should return the time zone expressed as a UTC offset", function() {
-      //   expect(date.strftime("%z")).to(equal, '-04:00');
-      // });
-
-      //| Might suffice to test formatting since browsers will 
-      //| automatically convert dates to the local timezone
       it ("should return the time zone formatted as a UTC offset", function() {
         expect((date.strftime("%z").match(/-?[0-9]{2}:[0-9]{2}/)) != null).to(equal , true);
       });
-
     });
     
     describe("`%%`", function(){

--- a/spec/lib/strftime_spec.js
+++ b/spec/lib/strftime_spec.js
@@ -3,7 +3,8 @@ Screw.Unit(function() {
     var date;
     before (function(){
       // Sunday June 7, 2009 4:05:01 PM
-      date = new Date("Sun Jun 07 2009 16:05:01 GMT-0400 (EDT)");
+      //Browser will always convert to local timezone 
+      date = new Date("Sun Jun 07 2009 16:05:01");
     });
     
     describe("`%a`", function(){
@@ -163,14 +164,21 @@ Screw.Unit(function() {
     
     describe("`%Z`", function(){
       it ("should return the time zone name", function() {
-        expect(date.strftime("%Z")).to(equal, '+00:00');
+        expect(date.strftime("%Z")).to(equal, 'PDT');
       });
     });
     
     describe("`%z`", function(){
-      it ("should return the time zone expressed as a UTC offset", function() {
-        expect(date.strftime("%z")).to(equal, '-04:00');
+      // it ("should return the time zone expressed as a UTC offset", function() {
+      //   expect(date.strftime("%z")).to(equal, '-04:00');
+      // });
+
+      //| Might suffice to test formatting since browsers will 
+      //| automatically convert dates to the local timezone
+      it ("should return the time zone formatted as a UTC offset", function() {
+        expect((date.strftime("%z").match(/-?[0-9]{2}:[0-9]{2}/)) != null).to(equal , true);
       });
+
     });
     
     describe("`%%`", function(){


### PR DESCRIPTION
Tested on a hand full of browsers and looks to work well on browsers that return a time zone name or abbreviation with the toTimeString() function. 
